### PR TITLE
Add path to input coerce errors in vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.1] - 2020-10-02
+
+### Fixed
+
+- Errors on coercing input type from variables now include the path to the error.
+
 ## [1.2.0] - 2020-09-29
 
 ### Added

--- a/pkg/ggql/input.go
+++ b/pkg/ggql/input.go
@@ -105,6 +105,13 @@ func (t *Input) CoerceIn(v interface{}) (interface{}, error) {
 				if cv, err := co.CoerceIn(ov); err == nil {
 					tv[k] = cv
 				} else {
+					gerr, _ := err.(*Error)
+					if gerr == nil {
+						gerr = &Error{Base: err, Path: []interface{}{k}}
+						err = gerr
+					} else {
+						gerr.in(k)
+					}
 					return nil, err
 				}
 			} else {

--- a/pkg/ggql/intscalar_test.go
+++ b/pkg/ggql/intscalar_test.go
@@ -50,6 +50,9 @@ func TestIntScalarCoerceIn(t *testing.T) {
 	_, err = scalar.CoerceIn(true)
 	checkNotNil(t, err, "Int.CoerceIn(true) error")
 
+	_, err = scalar.CoerceIn(3.2)
+	checkNotNil(t, err, "Int.CoerceIn(3.2) error")
+
 	v, err := scalar.CoerceIn(nil)
 	checkNil(t, err, "Int.CoerceIn(nil) error. %s", err)
 	checkNil(t, v, "Int.CoerceIn(nil) should return nil")

--- a/pkg/ggql/list.go
+++ b/pkg/ggql/list.go
@@ -104,6 +104,13 @@ func (t *List) CoerceIn(v interface{}) (interface{}, error) {
 				if err == nil {
 					list[i] = cv
 				} else {
+					gerr, _ := err.(*Error)
+					if gerr == nil {
+						gerr = &Error{Base: err, Path: []interface{}{i}}
+						err = gerr
+					} else {
+						gerr.in(i)
+					}
 					return nil, err
 				}
 			}

--- a/pkg/ggql/list_test.go
+++ b/pkg/ggql/list_test.go
@@ -85,4 +85,21 @@ func TestList(t *testing.T) {
 
 	_, err = list.Resolve(&ggql.Field{Name: "bad"}, nil)
 	checkNotNil(t, err, "List.Resolve(bad) should return an error.")
+
+	imp := ggql.Input{
+		Base: ggql.Base{
+			N:    "Imp",
+			Desc: "Some input.",
+		},
+	}
+	imp.AddField(&ggql.InputField{
+		Base: ggql.Base{
+			N: "a",
+		},
+		Type: &ggql.List{Base: root.GetType("String")},
+	})
+	list = ggql.List{Base: &imp}
+	_, err = list.CoerceIn([]interface{}{map[string]interface{}{"a": 37}})
+	checkNotNil(t, err, "List.CoerceIn([{a:37}]) should return an error")
+
 }

--- a/pkg/ggql/resolve.go
+++ b/pkg/ggql/resolve.go
@@ -92,7 +92,12 @@ func (root *Root) ResolveExecutable(
 						v, err = ic.CoerceIn(v)
 					}
 					if err != nil {
-						err = resError(vd.line, vd.col, "%s for %s", err, vd.Name)
+						if gerr, _ := err.(*Error); gerr != nil {
+							gerr.Line = vd.line
+							gerr.Column = vd.col
+						} else {
+							err = resError(vd.line, vd.col, "%s for %s", err, vd.Name)
+						}
 						return
 					}
 					opVars[vd.Name] = v

--- a/pkg/ggql/resolver_test.go
+++ b/pkg/ggql/resolver_test.go
@@ -131,6 +131,22 @@ func TestResolveExecutableErrors(t *testing.T) {
 `, err.Error(), "result mismatch for %s", src)
 }
 
+func TestResolveExecutableErrors2(t *testing.T) {
+	root := setupTestSongs(t, nil)
+
+	src := `query test($id: String = "Who"){artist(name: $id){name,bad}}`
+	exe, err := root.ParseExecutableString(src)
+	checkNil(t, err, "parsing executable fail. %s", err)
+
+	vars := map[string]interface{}{"id": "Fazerdaze"}
+
+	_, err = root.ResolveExecutable(exe, "", vars)
+	checkEqual(t, `Errors{
+  resolve error: bad is not a field in Artist at artist.bad from 1:57
+}
+`, err.Error(), "result mismatch for %s", src)
+}
+
 func TestResolveInterfaceParseError(t *testing.T) {
 	src := `{title`
 	expect := `{

--- a/pkg/ggql/resolverodd_test.go
+++ b/pkg/ggql/resolverodd_test.go
@@ -110,7 +110,7 @@ func (q *oddQuery) Resolve(field *ggql.Field, args map[string]interface{}) (inte
 	return nil, fmt.Errorf("type Query does not have field %s", field)
 }
 
-func testOddResolve(t *testing.T, src, expect string) {
+func testOddResolve(t *testing.T, src, expect string, vars map[string]interface{}) {
 	ggql.Sort = true
 	root := ggql.NewRoot(&oddSchema{})
 
@@ -119,7 +119,7 @@ func testOddResolve(t *testing.T, src, expect string) {
 
 	var b strings.Builder
 
-	result := root.ResolveString(src, "", nil)
+	result := root.ResolveString(src, "", vars)
 	_ = ggql.WriteJSONValue(&b, result, 2)
 
 	checkEqual(t, expect, b.String(), "result mismatch for %s", src)
@@ -137,7 +137,7 @@ func TestResolveInterfaceIntArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceInt64Array(t *testing.T) {
@@ -152,7 +152,7 @@ func TestResolveInterfaceInt64Array(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceAnyArray(t *testing.T) {
@@ -167,7 +167,7 @@ func TestResolveInterfaceAnyArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceBadAnyArray(t *testing.T) {
@@ -197,7 +197,7 @@ func TestResolveInterfaceBadAnyArray(t *testing.T) {
   ]
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceStrsArray(t *testing.T) {
@@ -212,7 +212,7 @@ func TestResolveInterfaceStrsArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceBoolsArray(t *testing.T) {
@@ -227,7 +227,7 @@ func TestResolveInterfaceBoolsArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceFloat32sArray(t *testing.T) {
@@ -242,7 +242,7 @@ func TestResolveInterfaceFloat32sArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceFloat64sArray(t *testing.T) {
@@ -257,7 +257,7 @@ func TestResolveInterfaceFloat64sArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceTimesArray(t *testing.T) {
@@ -270,7 +270,7 @@ func TestResolveInterfaceTimesArray(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceNestedErrors(t *testing.T) {
@@ -307,7 +307,7 @@ func TestResolveInterfaceNestedErrors(t *testing.T) {
   ]
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceEnumArg(t *testing.T) {
@@ -318,7 +318,7 @@ func TestResolveInterfaceEnumArg(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceEnumBadArg(t *testing.T) {
@@ -338,7 +338,7 @@ func TestResolveInterfaceEnumBadArg(t *testing.T) {
   ]
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceInputEnumBad(t *testing.T) {
@@ -358,7 +358,7 @@ func TestResolveInterfaceInputEnumBad(t *testing.T) {
   ]
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceListArg(t *testing.T) {
@@ -369,7 +369,30 @@ func TestResolveInterfaceListArg(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
+}
+
+func TestResolveInterfaceListVars(t *testing.T) {
+	src := `query call($arg: [Int!]!) {size(list: $arg)}`
+	expect := `{
+  "data": null,
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 14,
+          "line": 1
+        }
+      ],
+      "message": "can not coerce null into a Int!",
+      "path": [
+        1
+      ]
+    }
+  ]
+}
+`
+	testOddResolve(t, src, expect, map[string]interface{}{"arg": []interface{}{1, nil, 3}})
 }
 
 func TestResolveInterfaceListNullArg(t *testing.T) {
@@ -389,7 +412,7 @@ func TestResolveInterfaceListNullArg(t *testing.T) {
   ]
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceListEmptyArg(t *testing.T) {
@@ -400,7 +423,7 @@ func TestResolveInterfaceListEmptyArg(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }
 
 func TestResolveInterfaceNilTime(t *testing.T) {
@@ -411,5 +434,5 @@ func TestResolveInterfaceNilTime(t *testing.T) {
   }
 }
 `
-	testOddResolve(t, src, expect)
+	testOddResolve(t, src, expect, nil)
 }


### PR DESCRIPTION
The path to errors was not being generated when the argument was a complex input and also a variable.