### PR TITLE
Fix parser infinite loop, add validation bugfixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.6] - 2021-01-07
+
+### Fixed
+
+- Infinite loop in parser when enum contains singular invalid enum value name.
+- Name validation on fields, arguments, enums/values
+
 ## [1.2.5] - 2020-12-30
 
 ### Fixed
@@ -17,7 +24,7 @@ versioning.
 
 ### Fixed
 
-- List in complext types are now extracted.
+- List in complex types are now extracted.
 
 ## [1.2.3] - 2020-12-08
 

--- a/pkg/ggql/base.go
+++ b/pkg/ggql/base.go
@@ -106,15 +106,9 @@ func (b *Base) Validate(root *Root) (errs []error) {
 func (b *Base) validateFieldDefs(typeName string, fields *fieldList) (errs []error) {
 	if 0 < fields.Len() { // must have at least one field
 		for _, f := range fields.list {
-			if strings.HasPrefix(f.Name(), "__") {
-				errs = append(errs, fmt.Errorf("%w, %s is not a valid field name, it begins with '__' at %d:%d",
-					ErrValidation, f.Name(), f.line, f.col))
-			}
+			errs = append(errs, validateName(f.core, "field", f.N, f.line, f.col)...)
 			for _, a := range f.args.list {
-				if strings.HasPrefix(a.Name(), "__") {
-					errs = append(errs, fmt.Errorf("%w, %s is not a valid argument name, it begins with '__' at %d:%d",
-						ErrValidation, a.Name(), a.line, a.col))
-				}
+				errs = append(errs, validateName(a.core, "argument", a.N, a.line, a.col)...)
 				if !IsInputType(a.Type) {
 					errs = append(errs, fmt.Errorf("%w, argument %s of %s must be an input type at %d:%d",
 						ErrValidation, a.Name(), f.Name(), a.line, a.col))

--- a/pkg/ggql/directive.go
+++ b/pkg/ggql/directive.go
@@ -100,6 +100,7 @@ func (t *Directive) Validate(root *Root) (errs []error) {
 		}
 	}
 	for _, a := range t.args.list {
+		errs = append(errs, validateName(a.core, "argument", a.N, a.line, a.col)...)
 		if co, _ := a.Type.(InCoercer); co != nil {
 			if a.Default != nil {
 				if v, err := co.CoerceIn(a.Default); err != nil {

--- a/pkg/ggql/enum.go
+++ b/pkg/ggql/enum.go
@@ -85,6 +85,7 @@ func (t *Enum) Extend(x Type) error {
 
 // Validate a type.
 func (t *Enum) Validate(root *Root) (errs []error) {
+	errs = append(errs, root.validateTypeName("enum", t)...)
 	// All members must be Objects and there must be at least one member.
 	if 0 < t.values.Len() {
 		for _, ev := range t.values.list {
@@ -92,6 +93,8 @@ func (t *Enum) Validate(root *Root) (errs []error) {
 			case Symbol("true"), Symbol("false"), Symbol("null"):
 				errs = append(errs, fmt.Errorf("%w, %s is not a valid enum value for enum %s at %d:%d",
 					ErrValidation, ev.Value, t.Name(), ev.line, ev.col))
+			default:
+				errs = append(errs, validateName(t.core, "enum value", string(ev.Value), ev.line, ev.col)...)
 			}
 			for _, du := range ev.Directives {
 				errs = append(errs, root.validateDirUse(t.Name()+"."+string(ev.Value), Locate(ev), du)...)

--- a/pkg/ggql/input.go
+++ b/pkg/ggql/input.go
@@ -224,10 +224,7 @@ func (t *Input) reflectSet(rv reflect.Value, v interface{}) (err error) {
 func (t *Input) Validate(root *Root) (errs []error) {
 	if 0 < t.fields.Len() { // must have at least one field
 		for _, f := range t.fields.list {
-			if strings.HasPrefix(f.Name(), "__") {
-				errs = append(errs, fmt.Errorf("%w, %s is not a valid field name, it begins with '__' at %d:%d",
-					ErrValidation, f.Name(), f.line, f.col))
-			}
+			errs = append(errs, validateName(f.core, "field", f.N, f.line, f.col)...)
 			if !IsInputType(f.Type) {
 				errs = append(errs, fmt.Errorf("%w, %s does not return an input type at %d:%d",
 					ErrValidation, f.Name(), f.line, f.col))

--- a/pkg/ggql/sdlparser.go
+++ b/pkg/ggql/sdlparser.go
@@ -192,7 +192,10 @@ func (p *sdlParser) readEnumValue() (ev *EnumValue, err error) {
 	if desc, err = p.readDesc(); err == nil {
 		token, err = p.readToken()
 	}
-	if err == nil && 0 < len(token) {
+	if err == nil && len(token) == 0 {
+		err = fmt.Errorf("%w, invalid enum value name at %d:%d", ErrParse, p.line, p.col)
+	}
+	if err == nil {
 		ev = &EnumValue{Value: Symbol(token), Description: desc, line: p.line, col: p.col - len(token) - 1}
 		var du *DirectiveUse
 		for {


### PR DESCRIPTION
This fixes a parser bug which causes infinite looping when an Enum
contains a singular Enum Value which is not a valid Name. See example
below:

```graphql
enum Foo {
  %
}
```

Additionally validation has been added/enhanced on:

- Directive, Enum and Enum Value names
- Field names on Objects, Input Objects, and Interfaces
- Argument names on Fields and Directives