### PR TITLE
Bugfixes around type validation against interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.7] - 2021-01-16
+
+### Fixed
+- Validation bug when checking an object's list/non-null field argument matches
+  the type defined by the interface the object is implementing.
+
 ## [1.2.6] - 2021-01-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ versioning.
 ### Fixed
 - Validation bug when checking an object's list/non-null field argument matches
   the type defined by the interface the object is implementing.
+- Validation bug where an object field type is a Non-Null variant of a valid
+  sub-type of the interface field type the object is implementing.
 
 ## [1.2.6] - 2021-01-07
 

--- a/pkg/ggql/interface.go
+++ b/pkg/ggql/interface.go
@@ -35,6 +35,11 @@ func (t *Interface) Rank() int {
 	return rankInterface
 }
 
+// Fields returns a list of the FieldDefs.
+func (t *Interface) Fields() []*FieldDef {
+	return t.fields.list
+}
+
 // String representation of the type.
 func (t *Interface) String() string {
 	return t.SDL()

--- a/pkg/ggql/interface_test.go
+++ b/pkg/ggql/interface_test.go
@@ -88,6 +88,7 @@ interface Inty {
 	checkEqual(t, expectRoot, actual, "Interface SDL() mismatch")
 	checkEqual(t, expectStr, inty.String(), "Interface String() mismatch")
 	checkEqual(t, 8, inty.Rank(), "Interface Rank() mismatch")
+	checkEqual(t, len(inty.Fields()), 2, "Interface has two fields")
 	checkEqual(t, "Some interface.", inty.Description(), "Interface Description() mismatch")
 	checkEqual(t, 0, len(inty.Directives()), "Interface Directives() mismatch")
 

--- a/pkg/ggql/object.go
+++ b/pkg/ggql/object.go
@@ -168,6 +168,11 @@ func (t *Object) isSubType(target, sub Type) bool {
 	if typeEqual(target, sub) {
 		return true
 	}
+	if st, ok := sub.(*NonNull); ok && typeEqual(target, st.Base) {
+		// As a special case, if the interface expects type T and the
+		// implementation is T!, the implementation satisfies the interface.
+		return true
+	}
 	switch tt := target.(type) {
 	case *Union:
 		for _, m := range tt.Members {

--- a/pkg/ggql/sdlparser.go
+++ b/pkg/ggql/sdlparser.go
@@ -169,11 +169,7 @@ func (p *sdlParser) readEnum(desc string) (Type, error) {
 			if err == nil {
 				ev, err = p.readEnumValue()
 				if err == nil {
-					if ev == nil {
-						break
-					} else {
-						err = enum.values.add(ev)
-					}
+					err = enum.values.add(ev)
 				}
 			}
 			if err != nil {

--- a/pkg/ggql/type.go
+++ b/pkg/ggql/type.go
@@ -57,3 +57,21 @@ type Type interface {
 	// Column the type was defined on in the schema.
 	Column() int
 }
+
+// typeEqual returns true if a and b represent the same schema type. This works
+// in cases where equality comparison will not, such as when a & b's underlying
+// types are identical but their underlying values are non-nil pointers to
+// different structs.
+func typeEqual(a, b Type) bool {
+	switch ta := a.(type) {
+	case *List:
+		if tb, ok := b.(*List); ok {
+			return typeEqual(ta.Base, tb.Base)
+		}
+	case *NonNull:
+		if tb, ok := b.(*NonNull); ok {
+			return typeEqual(ta.Base, tb.Base)
+		}
+	}
+	return a.Name() == b.Name()
+}

--- a/pkg/ggql/validate_test.go
+++ b/pkg/ggql/validate_test.go
@@ -205,11 +205,11 @@ func TestRootValidateObject(t *testing.T) {
 		},
 		{
 			sdl:    `interface Imp {a(x: Int): Int} type Obj implements Imp {a(x: Float): Int}`,
-			expect: "argument return for x does not match interface at 1:59",
+			expect: "interface Imp not satisfied, argument return type for x does not match at 1:59",
 		},
 		{
 			sdl:    `interface Imp {a: Int} type Obj implements Imp {a(y: Int!): Int}`,
-			expect: "additional argument y to interface field must be optional at 1:51",
+			expect: "interface Imp not satisfied, additional argument y to field a must be optional at 1:51",
 		},
 		{
 			sdl:    `interface Imp {a: Float!} type Obj implements Imp {a: Int!}`,
@@ -282,4 +282,21 @@ func TestRootValidateNames(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestRootValidateObjectFieldArgs(t *testing.T) {
+	// Test that non-null and list field argument types are validated against an
+	// interface correctly.
+	sdl := `interface Inty {
+  field(arg: String!): Int
+  field2(arg: [String!]!): Int
+}
+type Obj implements Inty {
+  field(arg: String!): Int
+  field2(arg: [String!]!): Int
+}
+`
+	root := ggql.NewRoot(nil)
+	err := root.ParseString(sdl)
+	checkNil(t, err, "expected no error but got %q", err)
 }

--- a/pkg/ggql/validate_test.go
+++ b/pkg/ggql/validate_test.go
@@ -196,6 +196,10 @@ func TestRootValidateObject(t *testing.T) {
 			expect: "field a return type Float is not a sub-type of Int at 1:49",
 		},
 		{
+			sdl:    `interface Imp {a: [Int]} type Obj implements Imp {a: [Float]}`,
+			expect: "interface Imp not satisfied, field a return type [Float] is not a sub-type of [Int] at 1:51",
+		},
+		{
 			sdl:    `interface Imp {a(x: Int): Int} type Obj implements Imp {a: Int}`,
 			expect: "argument a to x missing at 1:57",
 		},
@@ -213,7 +217,7 @@ func TestRootValidateObject(t *testing.T) {
 		},
 		{
 			sdl:    `interface Imp {a: Float!} type Obj implements Imp {a: Int!}`,
-			expect: "field a return type Int! is not a sub-type of Float! at 1:52",
+			expect: "interface Imp not satisfied, field a return type Int! is not a sub-type of Float! at 1:52",
 		},
 		{
 			sdl:    `interface Imp { a: Imp, b: Int } type Obj implements Imp {a: Obj}`,
@@ -296,6 +300,13 @@ type Obj implements Inty {
   field2(arg: [String!]!): Int
 }
 `
+	root := ggql.NewRoot(nil)
+	err := root.ParseString(sdl)
+	checkNil(t, err, "expected no error but got %q", err)
+}
+
+func TestRootValidateObjectInterface(t *testing.T) {
+	sdl := "interface Inty { a: String } type Obj implements Inty { a: String! }"
 	root := ggql.NewRoot(nil)
 	err := root.ParseString(sdl)
 	checkNil(t, err, "expected no error but got %q", err)


### PR DESCRIPTION
This PR fixes two bugs in GGQL;

Bug 1 occurred when a field argument type was Non-null or List and was
validated to match the type of the interface the object is implementing.

The explanation below just talks about Lists but the same applies for
Non-null too.

The bug is caused because two separate instances of `*List` were added to
the types list of the root by the parser and later compared during
validation (more on this later). Comparing interfaces checks the
underlying values are identical, which for pointers is false when
non-nil and not pointing to the same struct.

This is fixed by replacing the equality comparison of the two arg types
(using == operator) with an equality function that checks the types
match all the way down to the base type name. This equality function
will work even if the two operands' underlying types are pointers to
separate structs.

I also considered making the parser only add one instance of the type to
the types list and look it up later. This would allow == comparison of
the underlying pointers however this would cause problems with reporting
line/column number in error messages. I noticed that the types added to
the type list were no longer in the list after the validation step of
the SDL parser, so I opted to go for the type equality function.


Bug 2 was that a validation error where this portion of the sub-type algorithm
in the GraphQL spec was not checked: 
> An object field type is a valid sub‐type if it is a Non‐Null variant of a valid 
> sub‐type of the interface field type.
https://spec.graphql.org/June2018/#sec-Validation.Fields