### PR TITLE
Bugfix: Race condition during concurrent resolves.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.10] - 2021-03-23
+
+### Fixed
+- Race condition when concurrently resolving executables.
+
 ## [1.2.9] - 2021-02-02
 
 ### Fixed

--- a/pkg/ggql/resolve.go
+++ b/pkg/ggql/resolve.go
@@ -67,7 +67,6 @@ func (root *Root) ResolveExecutable(
 	// Returned error can be either an array of errors as a Errors, an Error,
 	// or just a plain fmt.Errorf() return.
 
-	root.assureSchema()
 	op := exe.Ops[opName]
 	if op == nil {
 		if len(exe.Ops) == 1 {
@@ -505,13 +504,14 @@ func (root *Root) resolveField(
 			return
 		}
 	}
+	const queryType = "Query"
 	var ea2 []error
 	switch field.Name {
 	case "__typename":
 		result[field.key()] = t.Name()
 		return nil
 	case "__type":
-		if obj == root.queryObj {
+		if t.Name() == queryType {
 			var fv interface{} // field value
 			var av *ArgValue
 
@@ -543,7 +543,7 @@ func (root *Root) resolveField(
 		ea = append(ea, resWarnp(field, "__type meta-field is only on the query object"))
 		return
 	case "__schema":
-		if obj == root.queryObj {
+		if t.Name() == queryType {
 			var fv interface{} // field value
 
 			fv, ea2 = root.resolve(root, vars, field, root.uuSchemaType, depth)
@@ -584,9 +584,6 @@ func (root *Root) resolveField(
 	}
 	if err != nil {
 		ea = root.addError(field, ea, err)
-	}
-	if MaxResolveDepth == depth && root.queryObj == nil && field.Name == string(OpQuery) {
-		root.queryObj = attr
 	}
 	if IsNil(attr) {
 		result[field.key()] = nil

--- a/pkg/ggql/root.go
+++ b/pkg/ggql/root.go
@@ -35,7 +35,6 @@ type Root struct {
 	types         *typeList
 	dirs          *typeList
 	obj           interface{}
-	queryObj      interface{}
 	schema        *Schema
 	uuSchemaType  *uuSchema
 	AnyResolver   AnyResolver
@@ -314,6 +313,7 @@ func (root *Root) ParseReader(r io.Reader) error {
 		err = root.addExtends(extends...)
 	}
 	if err == nil {
+		root.assureSchema()
 		err = root.validate()
 	}
 	if err != nil {


### PR DESCRIPTION
Two race conditions were occurring during concurrent resolution of
executables where private fields on the ggql.Root were being set while
being concurrently read elsewhere. The fix applied was to remove the
operations that mutate the root from the code paths used during
resolving.

Closes #21 