### PR TITLE
Bugfix: Race conditions during reflection resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.11] - 2021-04-06
+
+### Fixed
+- Race condition when concurrently resolving executables using reflection.
+
 ## [1.2.10] - 2021-03-23
 
 ### Fixed

--- a/pkg/ggql/anyresolver_test.go
+++ b/pkg/ggql/anyresolver_test.go
@@ -76,7 +76,7 @@ func (ar *Any) Nth(list interface{}, i int) (result interface{}, err error) {
 	return 0, fmt.Errorf("expected a []interface{}, not a %T", list)
 }
 
-func setupAnySongs(t *testing.T) *ggql.Root {
+func setupAnySongs() (*ggql.Root, error) {
 	may5 := &Date{Year: 2017, Month: 5, Day: 5}
 	nov2 := &Date{Year: 2015, Month: 11, Day: 2}
 	sep28 := &Date{Year: 2018, Month: 11, Day: 2}
@@ -111,17 +111,20 @@ func setupAnySongs(t *testing.T) *ggql.Root {
 	root := ggql.NewRoot(schema)
 	root.AnyResolver = &Any{}
 
-	err := root.AddTypes(NewDateScalar())
-	checkNil(t, err, "no error should be returned when adding a Date type. %s", err)
+	if err := root.AddTypes(NewDateScalar()); err != nil {
+		return nil, fmt.Errorf("no error should be returned when adding a Date type: %w", err)
+	}
 
-	err = root.ParseString(songsSdl)
-	checkNil(t, err, "no error should be returned when parsing a valid SDL. %s", err)
+	if err := root.ParseString(songsSdl); err != nil {
+		return nil, fmt.Errorf("no error should be returned when parsing a valid SDL: %w", err)
+	}
 
-	return root
+	return root, nil
 }
 
 func testAnyResolve(t *testing.T, sdl, src, expect string) {
-	root := setupAnySongs(t)
+	root, err := setupAnySongs()
+	checkNil(t, err, "setupAnySongs should not return an error")
 
 	if 0 < len(sdl) {
 		err := root.ParseString(sdl)

--- a/pkg/ggql/benchmarks_test.go
+++ b/pkg/ggql/benchmarks_test.go
@@ -1,0 +1,58 @@
+package ggql_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/uhn/ggql/pkg/ggql"
+)
+
+func benchmarkResolveExecutable(root *ggql.Root, b *testing.B) {
+	ggql.Sort = false
+	exe, err := root.ParseExecutableString(`{__type(name: "Artist"){name} artists{songs{name}}}`)
+	if err != nil {
+		b.Fatalf("Parse executable failed: %s\n", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := root.ResolveExecutable(exe, "", nil); err != nil {
+			b.Errorf("Resolve failed: %s\n", err)
+		}
+	}
+}
+
+func BenchmarkResolveExecutableReflection(b *testing.B) {
+	// Benchmark GGQL resolving using the reflection approach.
+	schema := setupReflectSongs()
+	root := ggql.NewRoot(schema)
+	if err := root.AddTypes(NewDateScalar()); err != nil {
+		log.Fatalf("no error should be returned when adding a Date type. %s", err)
+	}
+	if err := root.ParseString(songsSdl); err != nil {
+		log.Fatalf("no error should be returned when parsing a valid SDL. %s", err)
+	}
+	benchmarkResolveExecutable(root, b)
+}
+
+func BenchmarkResolveExecutableInterface(b *testing.B) {
+	// Benchmark GGQL resolving using the interface approach.
+	schema := setupSongs()
+	root := ggql.NewRoot(schema)
+	if err := root.AddTypes(NewDateScalar()); err != nil {
+		log.Fatalf("no error should be returned when adding a Date type. %s", err)
+	}
+	if err := root.ParseString(songsSdl); err != nil {
+		log.Fatalf("no error should be returned when parsing a valid SDL. %s", err)
+	}
+	benchmarkResolveExecutable(root, b)
+}
+
+func BenchmarkResolveExecutableAnyResolver(b *testing.B) {
+	// Benchmark GGQL resolving using the AnyResolver approach.
+	root, err := setupAnySongs()
+	if err != nil {
+		log.Fatalf("setupAnySongs failed: %s", err)
+	}
+	benchmarkResolveExecutable(root, b)
+}

--- a/pkg/ggql/fielddef.go
+++ b/pkg/ggql/fielddef.go
@@ -17,6 +17,7 @@ package ggql
 import (
 	"io"
 	"reflect"
+	"sync"
 )
 
 // FieldDef in a representation of a field in an object or interface.
@@ -31,6 +32,7 @@ type FieldDef struct {
 
 	method  *reflect.Value
 	goField string
+	mu      sync.Mutex
 }
 
 // Write the type as SDL.

--- a/pkg/ggql/resolver_test.go
+++ b/pkg/ggql/resolver_test.go
@@ -2391,7 +2391,9 @@ func TestResolveConcurrent(t *testing.T) {
 	var roots []*ggql.Root
 	roots = append(roots, setupTestSongs(t, nil))
 	roots = append(roots, setupTestReflectSongs(t))
-	roots = append(roots, setupAnySongs(t))
+	anyResolverRoot, err := setupAnySongs()
+	checkNil(t, err, "setupAnySongs should not fail")
+	roots = append(roots, anyResolverRoot)
 
 	const nRoutines = 3
 	errs := make(chan error, nRoutines)

--- a/pkg/ggql/resolver_test.go
+++ b/pkg/ggql/resolver_test.go
@@ -2387,19 +2387,25 @@ func TestResolveValidateFieldExists(t *testing.T) {
 
 func TestResolveConcurrent(t *testing.T) {
 	// Performing concurrent resolution of executables should not fail or cause
-	// races.
-	root := setupTestSongs(t, nil)
+	// races using any of the resolving approaches.
+	var roots []*ggql.Root
+	roots = append(roots, setupTestSongs(t, nil))
+	roots = append(roots, setupTestReflectSongs(t))
+	roots = append(roots, setupAnySongs(t))
+
 	const nRoutines = 3
 	errs := make(chan error, nRoutines)
 	for i := 0; i < nRoutines; i++ {
 		go func() {
-			exe, err := root.ParseExecutableString(`{__type(name: "Artist"){name} artists{songs{name}}}`)
-			checkNil(t, err, "parse executable")
-			_, e := root.ResolveExecutable(exe, "", nil)
-			errs <- e
+			for _, root := range roots {
+				exe, err := root.ParseExecutableString(`{__type(name: "Artist"){name} artists{songs{name}}}`)
+				checkNil(t, err, "parse executable")
+				_, e := root.ResolveExecutable(exe, "", nil)
+				errs <- e
+			}
 		}()
 	}
-	for i := 0; i < nRoutines; i++ {
+	for i := 0; i < len(roots)*nRoutines; i++ {
 		checkNil(t, <-errs, "resolve executable should not fail")
 	}
 }


### PR DESCRIPTION
The previous bugfix did not address concurrent writes happening on
Field Definitions and Objects when resolving using the reflection
approach.

These were fixed by the addition of mutexes to synchronize the
reads/writes. From what I can tell the writes to the fields during
resolution cannot efficiently be done ahead of time because the
reflection objects may be created during the process of resolving (e.g.
after reading from a database). If there is a way to map GraphQL types
to a sample of their reflection object type ahead of time, the writes
(and need for synchronization) during resolution could be removed.