### PR TITLE
Add ParseFS method to Root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.15.x
+- 1.16.x
 addons:
   apt:
     packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.12] - 2021-06-12
+
+### Changed
+- Bump Go version to 1.16.
+
+### Added
+- ParseFS method to Root which allows parsing GraphQL schema from an fs.FS.
+
 ## [1.2.11] - 2021-04-06
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/uhn/ggql
 
-go 1.15
+go 1.16


### PR DESCRIPTION
This PR adds a ParseFS method to root which makes it very nice to parse a set of schema files from any fs.FS. The two common cases I have in mind for this feature are for parsing a local directory of files or an embedded `embed.FS`.