### PR TITLE
Order should not be important in stub generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.13] - 2021-06-22
+
+### Fixed
+- ggqlgen no longer requires input files to be in a dependent order when generating stubs.
+
 ## [1.2.12] - 2021-06-12
 
 ### Changed

--- a/cmd/ggqlgen/main.go
+++ b/cmd/ggqlgen/main.go
@@ -157,11 +157,29 @@ Usage: ggqlgen [options] [<schema-file>...]
 	for _, o := range overs.overs {
 		files = append(files, o.file)
 	}
-	if len(files) == 0 {
+	switch {
+	case len(files) == 0:
 		if err := root.ParseReader(os.Stdin); err != nil {
 			log.Fatalf("Failed to parse stdin: %s", err)
 		}
-	} else {
+	case 0 < len(stubDir):
+		var buf []byte
+		for _, filepath = range files {
+			sdl, err := getSDL(filepath)
+			if err != nil {
+				log.Fatalf("Failed to read schema file %s: %s", filepath, err)
+			}
+			buf = append(buf, sdl...)
+		}
+		if err := root.Parse(buf); err != nil {
+			log.Fatalf("Failed to parse file %s: %s", filepath, err)
+		}
+		for _, t := range root.Types() {
+			if !t.Core() {
+				exists[t.Name()] = true
+			}
+		}
+	default:
 		for _, filepath = range files {
 			var e *embed
 			for _, e2 := range embeds.embeds {


### PR DESCRIPTION
Makes stub generation a little more tolerant. Dependent order is still needed for embedded since it matters which file types are defined in. So small change that is helpful for stubs.