### PR TITLE
Add Extensions to Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Changes to the GraphQL package are listed here. Releases follow semantic
 versioning.
 
+## [1.2.14] - 2022-03-27
+
+### Added
+- Support for "extensions" field on returned GraphQL errors.
+
 ## [1.2.13] - 2021-06-22
 
 ### Fixed

--- a/pkg/ggql/errors.go
+++ b/pkg/ggql/errors.go
@@ -99,6 +99,11 @@ type Error struct {
 	// or nil then it does not apply to the response data or that
 	// determination could not be made.
 	Path []interface{}
+
+	// Extensions is reserved for implementors to add additional information to
+	// errors however they see fit, and there are no additional restrictions on
+	// its contents.
+	Extensions map[string]interface{}
 }
 
 // Error returns a string representation of the error.

--- a/pkg/ggql/resolve.go
+++ b/pkg/ggql/resolve.go
@@ -610,6 +610,7 @@ func (root *Root) addError(f *Field, ea []error, err error) []error {
 		}
 	case errors.As(err, &e1):
 		err = resWarn(f.line, f.col, "%s", err)
+		err.(*Error).Extensions = e1.Extensions //nolint:errorlint
 		ea = append(ea, err)
 	default:
 		ea = append(ea, resWarn(f.line, f.col, "%s", err))

--- a/pkg/ggql/util.go
+++ b/pkg/ggql/util.go
@@ -69,6 +69,9 @@ func formOneErrorResult(err error) map[string]interface{} {
 		if 0 < len(e.Path) {
 			em["path"] = e.Path
 		}
+		if e.Extensions != nil {
+			em["extensions"] = e.Extensions
+		}
 	} else {
 		em["message"] = err.Error()
 	}


### PR DESCRIPTION
The GraphQL Specification allows for an "extensions" field to be added
to errors for use by implementers to extend the error information
available to the user. This is useful for providing error codes or other
structured data.

This change adds support for error extensions. Implementers who return a
`*ggql.Error` from a resolver method containing Extensions data will now
see this data returned to the API caller.

See spec: http://spec.graphql.org/June2018/#sec-Errors